### PR TITLE
move from Symfony request and Response objects to Diactoros

### DIFF
--- a/app/ServiceProviders/RequestServiceProvider.php
+++ b/app/ServiceProviders/RequestServiceProvider.php
@@ -1,0 +1,23 @@
+<?php
+
+/*
+ *  ServiceProvider to implement PSR-7 request object
+ */
+
+namespace App\ServiceProviders;
+
+use League\Container\ServiceProvider\AbstractServiceProvider;
+use Zend\Diactoros\ServerRequestFactory;
+
+class RequestServiceProvider extends AbstractServiceProvider
+{
+    protected $provides = ['PsrRequestInterface'];
+
+    public function register()
+    {
+        $this->getContainer()->add('PsrRequestInterface', function () {
+            $psrRequest = ServerRequestFactory::fromGlobals();
+            return $psrRequest;
+        });
+    }
+}

--- a/app/ServiceProviders/ResponseServiceProvider.php
+++ b/app/ServiceProviders/ResponseServiceProvider.php
@@ -1,0 +1,22 @@
+<?php
+
+/*
+ *  ServiceProvider to implement PSR-7 response object
+ */
+
+namespace App\ServiceProviders;
+
+use League\Container\ServiceProvider\AbstractServiceProvider;
+use Zend\Diactoros\Response;
+
+class ResponseServiceProvider extends AbstractServiceProvider
+{
+    protected $provides = ['PsrResponseInterface'];
+
+    public function register()
+    {
+        $this->getContainer()->add('PsrResponseInterface', function () {
+            return new Response();
+        });
+    }
+}

--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,8 @@
         "doctrine/orm": "^2.5",
         "symfony/yaml": "^3.3",
         "monolog/monolog": "^1.23",
-        "twig/twig": "^2.0"
+        "twig/twig": "^2.0",
+        "zendframework/zend-diactoros": "^1.6"
     },
     "autoload": {
         "files": [
@@ -31,7 +32,8 @@
         "psr-4": {
             "Lib\\": "lib/",
             "Http\\": "Http/",
-            "Database\\": "Database/"
+            "Database\\": "Database/",
+            "App\\": "app/"
         }
     },
     "autoload-dev": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "content-hash": "6435403571c51d25a79e59c028ff21ba",
+    "content-hash": "5cd9f1439ea8e39bd0ed0838ff4c0e6a",
     "packages": [
         {
             "name": "container-interop/container-interop",
@@ -1598,6 +1598,58 @@
                 "environment"
             ],
             "time": "2016-09-01T10:05:43+00:00"
+        },
+        {
+            "name": "zendframework/zend-diactoros",
+            "version": "1.6.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/zendframework/zend-diactoros.git",
+                "reference": "2faa791b66bac33ca40031d8bce03b7dc8143490"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/zendframework/zend-diactoros/zipball/2faa791b66bac33ca40031d8bce03b7dc8143490",
+                "reference": "2faa791b66bac33ca40031d8bce03b7dc8143490",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^5.6 || ^7.0",
+                "psr/http-message": "^1.0"
+            },
+            "provide": {
+                "psr/http-message-implementation": "1.0"
+            },
+            "require-dev": {
+                "ext-dom": "*",
+                "ext-libxml": "*",
+                "phpunit/phpunit": "^5.7.16 || ^6.0.8",
+                "zendframework/zend-coding-standard": "~1.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.6-dev",
+                    "dev-develop": "1.7-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Zend\\Diactoros\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-2-Clause"
+            ],
+            "description": "PSR HTTP Message implementations",
+            "homepage": "https://github.com/zendframework/zend-diactoros",
+            "keywords": [
+                "http",
+                "psr",
+                "psr-7"
+            ],
+            "time": "2017-09-13T14:47:08+00:00"
         }
     ],
     "packages-dev": [

--- a/lib/Framework/Container.php
+++ b/lib/Framework/Container.php
@@ -4,15 +4,14 @@ namespace Lib\Framework;
 
 use League\Container\Container as LeagueContainer;
 use League\Container\ReflectionContainer;
-use Symfony\Component\HttpFoundation\Request;
-use Symfony\Component\HttpFoundation\Response;
+use Psr\Http\Message\ServerRequestInterface;
+use Psr\Http\Message\ResponseInterface;
 use Lib\Framework\Core;
 use Lib\Framework\Router;
 use Dotenv\Dotenv;
 use Dotenv\Exception\InvalidPathException;
 use Lib\Database\Connection;
 use Lib\Framework\Config;
-
 use Monolog\Logger;
 use Monolog\Handler\StreamHandler;
 
@@ -27,18 +26,11 @@ class Container extends LeagueContainer
             new ReflectionContainer
         );
 
-        $this->add('Request', function () {
-            $request = new Request;
-            return $request->createFromGlobals();
-        });
-
-        $this->add('Response', function () {
-            $response = new Response;
-            return $response;
-        });
+        $this->addServiceProvider('App\ServiceProviders\ResponseServiceProvider');
+        $this->addServiceProvider('App\ServiceProviders\RequestServiceProvider');
 
         $this->add('Router', function () {
-            $response = $this->get('Response');
+            $response = $this->get('PsrResponseInterface');
             $router = new Router($response);
             return $router;
         });

--- a/lib/Framework/Core.php
+++ b/lib/Framework/Core.php
@@ -2,12 +2,10 @@
 
 namespace Lib\Framework;
 
-use Symfony\Component\HttpFoundation\Request;
-use Symfony\Component\HttpKernel\HttpKernelInterface;
 use Lib\Framework\Container;
 use FastRoute\RouteCollector;
 
-class Core implements HttpKernelInterface
+class Core
 {
 
     protected $container;
@@ -22,7 +20,7 @@ class Core implements HttpKernelInterface
     public function __construct()
     {
         $this->container = new Container;
-        $this->request = $this->container->get('Request');
+        $this->request = $this->container->get('PsrRequestInterface');
         $this->baseDir = $this->container->get('BaseDir');
         $this->dotenv = $this->container->get('Dotenv');
         $this->router = $this->container->get('Router');
@@ -47,12 +45,6 @@ class Core implements HttpKernelInterface
             }
         }
         throw new \BadMethodCallException("Method $method is not valid");
-    }
-
-    public function handle(Request $request, $type = HttpKernelInterface::MASTER_REQUEST, $catch = true)
-    {
-        //TODO:: fix ?
-        return $response;
     }
 
     // Associates an URL with a callback function
@@ -86,9 +78,7 @@ class Core implements HttpKernelInterface
             $this->readRoutes($r);
         };
         
-        $this->response = $this->router->dispatch($this->request, $this->routeDefinitionCallback);
-        $this->response->sendHeaders();
-        return $this->response->sendContent();
+        $this->router->dispatch($this->request, $this->routeDefinitionCallback);
     }
 
     // Clean up

--- a/public/index.php
+++ b/public/index.php
@@ -44,4 +44,4 @@ $_SESSION['timeout'] = time();
 // set up the application
 $app = new \Lib\Framework\Core();
 
-$response = $app->run();
+$app->run();


### PR DESCRIPTION
I made this change to make PSR-7 compliance easier. Developing middleware functionality, and testing should be easier with these changes.

@MisterBrownRSA  Would you take a look at the change and comment? You have contributed a lot, and I would appreciate your comments.

Others are welcome to comment as well. I am very open to input.
I would like to merge soon, though.