### PR TITLE
Fixes #112.

### DIFF
--- a/lib/Framework/Container.php
+++ b/lib/Framework/Container.php
@@ -68,5 +68,8 @@ class Container extends LeagueContainer
                 'auto_reload' => true,
             ));
         }, true);
+
+        // Add additional default error pages here.
+        $this->add('template.defaults.404', 'errors/404.twig');
     }
 }

--- a/lib/Framework/ResponseBody.php
+++ b/lib/Framework/ResponseBody.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace Lib\Framework;
+
+use Zend\Diactoros\Stream;
+
+class ResponseBody extends Stream
+{
+    public static function createFromString($body)
+    {
+        $tmpFile = \tmpfile();
+        \fwrite($tmpFile, $body);
+
+        return new ResponseBody($tmpFile);
+    }
+}

--- a/lib/Framework/Router.php
+++ b/lib/Framework/Router.php
@@ -17,7 +17,7 @@ class Router
 {
     
     private $dispatcher;
-    public $response;
+    private $response;
 
     public function __construct(ResponseInterface $response)
     {
@@ -50,11 +50,11 @@ class Router
     public function dispatch($request, $routeDefinitionCallback)
     {
         $routeInfo = $this->getRouteInfo($request, $routeDefinitionCallback);
+
         switch ($routeInfo[0]) {
             case Dispatcher::NOT_FOUND:
-                $newResponse = $this->response->withStatus(404);
-                return $newResponse;
-                break;
+                return $this->response->withStatus(404);
+
             case Dispatcher::METHOD_NOT_ALLOWED:
                 $response->setContent('405 - Method not allowed');
                 $response->setStatusCode(405);

--- a/resources/views/errors/404.twig
+++ b/resources/views/errors/404.twig
@@ -1,0 +1,2 @@
+<h1>404: Page not found</h1>
+<p>This page could not be found.</p>


### PR DESCRIPTION
Error page templates are referenced by the HTTP status code.

Additional template paths need to be added to the `Container`, and those template paths need to be created.