### PR TITLE
Bug session gc

### DIFF
--- a/Config/app.php
+++ b/Config/app.php
@@ -1,0 +1,13 @@
+<?php
+
+return [
+/* 
+ * Application configurations
+ * these are general, application-wide
+ * configuration values
+ */
+
+    'app' => [
+        'gcProb' => getEnv('APP_SESSION_GARBAGECOLLECTION', 1),
+    ],
+];

--- a/Config/database.php
+++ b/Config/database.php
@@ -4,7 +4,7 @@ return [
 
     /*
      * Database connections
-     * Currently only SQLite is set up
+     * Currently only SQLite & mySQL are set up
      * others to come soon
     */
    

--- a/lib/Framework/Config.php
+++ b/lib/Framework/Config.php
@@ -17,7 +17,7 @@ class Config implements ArrayAccess
             $configs = include($configFile);
         
             foreach ($configs as $config) {
-                $this->config = $config;
+                $this->config += $config;
             }
         }
     }

--- a/public/index.php
+++ b/public/index.php
@@ -22,7 +22,6 @@ require __DIR__.'/../vendor/autoload.php';
 // start the session
 $config = new \Lib\Framework\Config;
 $gcProb = $config['gcProb'];
-debugVar($gcProb);
 ini_set('session.save_path', dirname(__FILE__, 2) . '/storage/sessions');
 ini_set('session.gc_probability', $gcProb);
 session_start();

--- a/public/index.php
+++ b/public/index.php
@@ -20,8 +20,11 @@ require __DIR__.'/../vendor/autoload.php';
 
 // set session storage location and
 // start the session
+$config = new \Lib\Framework\Config;
+$gcProb = $config['gcProb'];
+debugVar($gcProb);
 ini_set('session.save_path', dirname(__FILE__, 2) . '/storage/sessions');
-ini_set('session.gc_probability', 1);
+ini_set('session.gc_probability', $gcProb);
 session_start();
 
 // set the timeout for the session


### PR DESCRIPTION
this PR gives devs the ability to control session garbage collection. During development and testing, and on low traffic sites, the .env value should be set higher.