### PR TITLE
Fixed initial test errors

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -44,6 +44,7 @@
     },
     "require-dev": {
         "phpunit/phpunit": "^6.3",
-        "guzzlehttp/guzzle": "^6.3"
+        "guzzlehttp/guzzle": "^6.3",
+        "symfony/process": "^4.1"
     }
 }

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "content-hash": "b9a6bce3d9132d40298a10e1b2fd5081",
+    "content-hash": "b7b35db46bd9ebd8f40a037775807fb2",
     "packages": [
         {
             "name": "container-interop/container-interop",
@@ -3282,6 +3282,55 @@
             "description": "Library that helps with managing the version number of Git-hosted PHP projects",
             "homepage": "https://github.com/sebastianbergmann/version",
             "time": "2016-10-03T07:35:21+00:00"
+        },
+        {
+            "name": "symfony/process",
+            "version": "v4.1.6",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/process.git",
+                "reference": "ee33c0322a8fee0855afcc11fff81e6b1011b529"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/process/zipball/ee33c0322a8fee0855afcc11fff81e6b1011b529",
+                "reference": "ee33c0322a8fee0855afcc11fff81e6b1011b529",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.1.3"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "4.1-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Component\\Process\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Fabien Potencier",
+                    "email": "fabien@symfony.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony Process Component",
+            "homepage": "https://symfony.com",
+            "time": "2018-10-02T12:40:59+00:00"
         },
         {
             "name": "theseer/tokenizer",

--- a/tests/unit/MiddlewareTest.php
+++ b/tests/unit/MiddlewareTest.php
@@ -5,17 +5,23 @@ namespace Tests\Unit;
 use Tests\TestCase;
 use GuzzleHttp\Client;
 use GuzzleHttp\Cookie\CookieJarInterface;
+use Symfony\Component\Process\Process;
 
 class MiddlewareTest extends TestCase
 {
     private $http;
     private $app;
+    private $process;
 
     public function setUp()
     {
+        $public_path = realpath(__DIR__.'/../../public');
+        $this->process = new Process("php -S localhost:8890 -t $public_path");
+        $this->process->start();
         $this->http = new Client(
             [
-                'base_uri' => 'https://chassis.local/',                 'verify' => false,
+                'base_uri' => 'http://localhost:8890',
+                'verify' => false,
                 'cookies' => true,
             ]
         );
@@ -24,6 +30,7 @@ class MiddlewareTest extends TestCase
     public function tearDown()
     {
         $this->http = null;
+        $this->process->stop();
     }
 
     // confirm that user list page requires log in
@@ -33,7 +40,7 @@ class MiddlewareTest extends TestCase
 
         $this->assertEquals(200, $response->getStatusCode());
 
-        $contentType = $response->getHeaders()["Content-Type"][0];
+        $contentType = $response->getHeader('Content-Type')[0];
         $this->assertEquals("text/html; charset=UTF-8", $contentType);
         $body = $response->getBody();
         $body = $body->getContents();
@@ -50,7 +57,7 @@ class MiddlewareTest extends TestCase
 
         $this->assertEquals(200, $response->getStatusCode());
 
-        $contentType = $response->getHeaders()["Content-Type"][0];
+        $contentType = $response->getHeader('Content-Type')[0];
         $this->assertEquals("text/html; charset=UTF-8", $contentType);
         $body = $response->getBody();
         $body = $body->getContents();
@@ -59,7 +66,7 @@ class MiddlewareTest extends TestCase
             $body
         );
     }
-    
+
     // confirm that content list page requires log in
     public function testContentAuth()
     {
@@ -67,7 +74,7 @@ class MiddlewareTest extends TestCase
 
         $this->assertEquals(200, $response->getStatusCode());
 
-        $contentType = $response->getHeaders()["Content-Type"][0];
+        $contentType = $response->getHeader('Content-Type')[0];
         $this->assertEquals("text/html; charset=UTF-8", $contentType);
         $body = $response->getBody();
         $body = $body->getContents();
@@ -76,7 +83,7 @@ class MiddlewareTest extends TestCase
             $body
         );
     }
-    
+
     // confirm that content detail page requires log in
     public function testContentDetailAuth()
     {
@@ -84,7 +91,7 @@ class MiddlewareTest extends TestCase
 
         $this->assertEquals(200, $response->getStatusCode());
 
-        $contentType = $response->getHeaders()["Content-Type"][0];
+        $contentType = $response->getHeader('Content-Type')[0];
         $this->assertEquals("text/html; charset=UTF-8", $contentType);
         $body = $response->getBody();
         $body = $body->getContents();
@@ -93,7 +100,7 @@ class MiddlewareTest extends TestCase
             $body
         );
     }
-    
+
     // confirm that content update page requires log in
     public function testContentUpdateDetailAuth()
     {
@@ -101,7 +108,7 @@ class MiddlewareTest extends TestCase
 
         $this->assertEquals(200, $response->getStatusCode());
 
-        $contentType = $response->getHeaders()["Content-Type"][0];
+        $contentType = $response->getHeader('Content-Type')[0];
         $this->assertEquals("text/html; charset=UTF-8", $contentType);
         $body = $response->getBody();
         $body = $body->getContents();

--- a/tests/unit/MiddlewareTest.php
+++ b/tests/unit/MiddlewareTest.php
@@ -11,13 +11,23 @@ class MiddlewareTest extends TestCase
 {
     private $http;
     private $app;
-    private $process;
+    private static $process;
+
+    public static function setUpBeforeClass()
+    {
+        $public_path = realpath(__DIR__.'/../../public');
+        self::$process = new Process("exec php -S localhost:8890 -t $public_path");
+        self::$process->start();
+        usleep(2000000);
+    }
+
+    public static function tearDownAfterClass()
+    {
+        self::$process->stop();
+    }
 
     public function setUp()
     {
-        $public_path = realpath(__DIR__.'/../../public');
-        $this->process = new Process("php -S localhost:8890 -t $public_path");
-        $this->process->start();
         $this->http = new Client(
             [
                 'base_uri' => 'http://localhost:8890',
@@ -30,7 +40,6 @@ class MiddlewareTest extends TestCase
     public function tearDown()
     {
         $this->http = null;
-        $this->process->stop();
     }
 
     // confirm that user list page requires log in

--- a/tests/unit/RoutesTest.php
+++ b/tests/unit/RoutesTest.php
@@ -5,20 +5,26 @@ namespace Tests\RoutesTest;
 use Tests\TestCase;
 use Zend\Diactoros\ServerRequestFactory;
 use GuzzleHttp\Client;
+use Symfony\Component\Process\Process;
 
 class RoutesTest extends TestCase
 {
     private $http;
     private $app;
+    private $process;
 
     public function setUp()
     {
-        $this->http = new Client(['base_uri' => 'https://chassis.local/', 'verify' => false]);
+        $public_path = realpath(__DIR__.'/../../public');
+        $this->process = new Process("php -S localhost:8890 -t public/");
+        $this->process->start();
+        $this->http = new Client(['base_uri' => 'http://localhost:8890', 'verify' => false]);
     }
 
     public function tearDown()
     {
         $this->http = null;
+        $this->process->stop();
     }
 
     public function testGet()
@@ -27,7 +33,7 @@ class RoutesTest extends TestCase
 
         $this->assertEquals(200, $response->getStatusCode());
 
-        $contentType = $response->getHeaders()["Content-Type"][0];
+        $contentType = $response->getHeader('Content-Type')[0];
         $this->assertEquals("text/html; charset=UTF-8", $contentType);
     }
 }

--- a/tests/unit/RoutesTest.php
+++ b/tests/unit/RoutesTest.php
@@ -11,20 +11,29 @@ class RoutesTest extends TestCase
 {
     private $http;
     private $app;
-    private $process;
+    private static $process;
 
     public function setUp()
     {
-        $public_path = realpath(__DIR__.'/../../public');
-        $this->process = new Process("php -S localhost:8890 -t public/");
-        $this->process->start();
         $this->http = new Client(['base_uri' => 'http://localhost:8890', 'verify' => false]);
     }
 
     public function tearDown()
     {
         $this->http = null;
-        $this->process->stop();
+    }
+
+    public static function setUpBeforeClass()
+    {
+        $public_path = realpath(__DIR__.'/../../public');
+        self::$process = new Process("exec php -S localhost:8890 -t $public_path");
+        self::$process->start();
+        usleep(2000000);
+    }
+
+    public static function tearDownAfterClass()
+    {
+        self::$process->stop();
     }
 
     public function testGet()


### PR DESCRIPTION
added local php server start for testing with guzzle; fixed content-type tests;

process from starting to contribute:

1. git clone
2. copy .env.example to .env
3. ./vendor/phpunit/phpunit/phphunit

All tests should pass

Note:  I used port 8890 - not sure this is good or bad.  I didn't want to use 8080 or 8888 since you could already be using that for manual development testing