### PR TITLE
Update to load the .env file using existing technologies.

### DIFF
--- a/Config/database.php
+++ b/Config/database.php
@@ -1,4 +1,11 @@
 <?php
+if (!getenv('DATABASE_PATH')) {
+    // crank up the Composer autoloading
+    require __DIR__.'/../vendor/autoload.php';
+
+    // load environment variables
+    \Lib\Framework\EnvVarsLoader::loadEnvVars();
+}
 
 return [
 
@@ -7,7 +14,7 @@ return [
      * Currently only SQLite & mySQL are set up
      * others to come soon
     */
-   
+
     'connections' => [
         'sqlite' => [
             'driver' => 'sqlite',


### PR DESCRIPTION
This appears to happen on Windows more than Unix based clients, but the .env is not automatically loaded by Doctrine, and so the getenv functions do not produce anything. 