### PR TITLE
Feature add logging system

### DIFF
--- a/Config/app.php
+++ b/Config/app.php
@@ -7,7 +7,6 @@ return [
  * configuration values
  */
 
-    'app' => [
-        'gcProb' => getEnv('APP_SESSION_GARBAGECOLLECTION', 1),
-    ],
+    'gcProb' => getEnv('APP_SESSION_GARBAGECOLLECTION', 1),
+
 ];

--- a/Config/logging.php
+++ b/Config/logging.php
@@ -1,0 +1,25 @@
+<?php
+
+/**
+ * This configuration allows to configure multiple files for different log level output.
+ * Logging output is per default placed in the storage folder.
+ *
+ * Only a debug path needs to be specified.
+ */
+return [
+
+    'folder' => 'logs',
+
+    // Datetime format to generate new log files for arbitrary time periods
+    'prefix' => [
+        'format' => 'Y-m-d',
+        'separator' => '_',
+    ],
+
+    // Where to persist logging output
+    'output' => [
+        'emergency' => 'emergency.log',
+        'debug' => 'debug.log',
+    ],
+
+];

--- a/lib/Database/Connection.php
+++ b/lib/Database/Connection.php
@@ -13,16 +13,14 @@ class Connection
 {
     public $entitymanager;
     private $isDevMode = true;
-    private $config;
 
     public function __construct()
     {
-        $this->config = new ConfigManager;
         $driver = envar('DATABASE_DRIVER', 'pdo_mysql');
         $dbType = envar('DATABASE_TYPE', 'mysql');
         switch ($dbType) {
             case "sqlite":
-                $path = dirname(__FILE__, 3) . "/" . $this->config->get("database.$dbType.database");
+                $path = dirname(__FILE__, 3) . "/" . ConfigManager::get("database.$dbType.database");
                 $conn = array(
                         'driver' => $driver,
                         'path' => $path,

--- a/lib/Database/Connection.php
+++ b/lib/Database/Connection.php
@@ -22,7 +22,7 @@ class Connection
         $dbType = envar('DATABASE_TYPE', 'mysql');
         switch ($dbType) {
             case "sqlite":
-                $path = dirname(__FILE__, 3) . "/" . $this->config[$dbType]['database'];
+                $path = dirname(__FILE__, 3) . "/" . $this->config['database'][$dbType]['database'];
                 $conn = array(
                         'driver' => $driver,
                         'path' => $path,

--- a/lib/Database/Connection.php
+++ b/lib/Database/Connection.php
@@ -4,7 +4,7 @@ namespace Lib\Database;
 
 use Doctrine\ORM\Tools\Setup;
 use Doctrine\ORM\EntityManager;
-use Lib\Framework\Config;
+use Lib\Framework\ConfigManager;
 use Doctrine\ORM\Mapping\Driver\AnnotationDriver;
 use Doctrine\Common\Annotations\AnnotationReader;
 use Doctrine\Common\Annotations\AnnotationRegistry;
@@ -17,12 +17,12 @@ class Connection
 
     public function __construct()
     {
-        $this->config = new Config;
+        $this->config = new ConfigManager;
         $driver = envar('DATABASE_DRIVER', 'pdo_mysql');
         $dbType = envar('DATABASE_TYPE', 'mysql');
         switch ($dbType) {
             case "sqlite":
-                $path = dirname(__FILE__, 3) . "/" . $this->config['database'][$dbType]['database'];
+                $path = dirname(__FILE__, 3) . "/" . $this->config->get("database.$dbType.database");
                 $conn = array(
                         'driver' => $driver,
                         'path' => $path,

--- a/lib/Framework/Config.php
+++ b/lib/Framework/Config.php
@@ -4,10 +4,18 @@ namespace Lib\Framework;
 
 use ArrayAccess;
 
+/**
+ * Class Config
+ * @package Lib\Framework
+ */
 class Config implements ArrayAccess
 {
-    private $config = array();
-    
+    /** @var array  */
+    private $config = [];
+
+    /**
+     * Config constructor.
+     */
     public function __construct()
     {
         // Read the config files
@@ -15,13 +23,16 @@ class Config implements ArrayAccess
 
         foreach (glob($configDir) as $configFile) {
             $configs = include($configFile);
-        
-            foreach ($configs as $config) {
-                $this->config += $config;
-            }
+
+            $configName = pathinfo($configFile)['filename'];
+            $this->config[$configName] = $configs;
         }
     }
 
+    /**
+     * @param mixed $offset
+     * @param mixed $value
+     */
     public function offsetSet($offset, $value)
     {
         if (is_null($offset)) {
@@ -31,16 +42,27 @@ class Config implements ArrayAccess
         }
     }
 
+    /**
+     * @param mixed $offset
+     * @return bool
+     */
     public function offsetExists($offset)
     {
         return isset($this->config[$offset]);
     }
 
+    /**
+     * @param mixed $offset
+     */
     public function offsetUnset($offset)
     {
         unset($this->config[$offset]);
     }
 
+    /**
+     * @param mixed $offset
+     * @return mixed|null
+     */
     public function offsetGet($offset)
     {
          return isset($this->config[$offset]) ? $this->config[$offset] : null;

--- a/lib/Framework/ConfigManager.php
+++ b/lib/Framework/ConfigManager.php
@@ -8,7 +8,7 @@ use ArrayAccess;
  * Class Config
  * @package Lib\Framework
  */
-class Config implements ArrayAccess
+class ConfigManager implements ArrayAccess
 {
     /** @var array  */
     private $config = [];
@@ -66,5 +66,28 @@ class Config implements ArrayAccess
     public function offsetGet($offset)
     {
          return isset($this->config[$offset]) ? $this->config[$offset] : null;
+    }
+
+    /**
+     * Takes in path in dot-notation and returns the appropriate value. (e.g. 'app.gcProb')
+     *
+     * @param $property
+     * @return mixed|null
+     */
+    public function get($property)
+    {
+        $value = $this->config;
+        $path = explode('.', $property);
+
+        while(sizeof($path) > 0 && is_array($value)) {
+            $nextKey = array_shift($path);
+            if (! key_exists($nextKey, $value)) {
+                return null;
+            }
+            $value = $value[$nextKey];
+        }
+
+        return $value;
+
     }
 }

--- a/lib/Framework/ConfigManager.php
+++ b/lib/Framework/ConfigManager.php
@@ -10,16 +10,40 @@ use ArrayAccess;
  */
 class ConfigManager implements ArrayAccess
 {
-    /** @var array  */
+    /** @var static */
+    protected static $instance;
+
+    /** @var array */
     private $config = [];
+
+    /**
+     * @return ConfigManager
+     */
+    public static function instance()
+    {
+        if (!static::$instance) {
+            static::$instance = new self;
+        }
+
+        return static::$instance;
+    }
+
+    /**
+     * @param $property
+     * @return mixed|null
+     */
+    public static function get($property)
+    {
+        return static::instance()->getProperty($property);
+    }
 
     /**
      * Config constructor.
      */
-    public function __construct()
+    protected function __construct()
     {
         // Read the config files
-        $configDir =  dirname(__FILE__, 3) . "/Config/*.php";
+        $configDir = dirname(__FILE__, 3) . "/Config/*.php";
 
         foreach (glob($configDir) as $configFile) {
             $configs = include($configFile);
@@ -65,7 +89,7 @@ class ConfigManager implements ArrayAccess
      */
     public function offsetGet($offset)
     {
-         return isset($this->config[$offset]) ? $this->config[$offset] : null;
+        return isset($this->config[$offset]) ? $this->config[$offset] : null;
     }
 
     /**
@@ -74,14 +98,14 @@ class ConfigManager implements ArrayAccess
      * @param $property
      * @return mixed|null
      */
-    public function get($property)
+    protected function getProperty($property)
     {
         $value = $this->config;
         $path = explode('.', $property);
 
-        while(sizeof($path) > 0 && is_array($value)) {
+        while (sizeof($path) > 0 && is_array($value)) {
             $nextKey = array_shift($path);
-            if (! key_exists($nextKey, $value)) {
+            if (!key_exists($nextKey, $value)) {
                 return null;
             }
             $value = $value[$nextKey];

--- a/lib/Framework/Container.php
+++ b/lib/Framework/Container.php
@@ -57,7 +57,7 @@ class Container extends LeagueContainer
         });
 
         $this->add('Config', function () {
-            $config = new Config;
+            $config = new ConfigManager;
             return $config;
         });
 

--- a/lib/Framework/Container.php
+++ b/lib/Framework/Container.php
@@ -4,6 +4,7 @@ namespace Lib\Framework;
 
 use League\Container\Container as LeagueContainer;
 use League\Container\ReflectionContainer;
+use Lib\Framework\Log\LogManager;
 use Psr\Http\Message\ServerRequestInterface;
 use Psr\Http\Message\ResponseInterface;
 use Dotenv\Dotenv;
@@ -61,8 +62,7 @@ class Container extends LeagueContainer
         });
 
         $this->add('Logger', function () {
-            $log = new Logger('CHASSISPHP');
-            $log->pushHandler(new StreamHandler(dirname(__FILE__, 3) . 'Storage/logs/app.log', LOGGER::DEBUG));
+            return new LogManager($this);
         });
 
         $this->add('Twig', function () {

--- a/lib/Framework/Container.php
+++ b/lib/Framework/Container.php
@@ -57,8 +57,7 @@ class Container extends LeagueContainer
         });
 
         $this->add('Config', function () {
-            $config = new ConfigManager;
-            return $config;
+            return ConfigManager::instance();
         });
 
         $this->add('Logger', function () {

--- a/lib/Framework/Container.php
+++ b/lib/Framework/Container.php
@@ -52,8 +52,7 @@ class Container extends LeagueContainer
         });
 
         $this->add('Connection', function () {
-            $config = $this->get('Config');
-            $connection = new Connection($config);
+            $connection = new Connection();
             return $connection;
         });
 

--- a/lib/Framework/Log/LogManager.php
+++ b/lib/Framework/Log/LogManager.php
@@ -1,0 +1,190 @@
+<?php
+/**
+ * Created by IntelliJ IDEA.
+ * User: dominik
+ * Date: 10/14/18
+ * Time: 8:15 AM
+ */
+
+namespace Lib\Framework\Log;
+
+use Lib\Framework\ConfigManager;
+use Lib\Framework\Container;
+use Monolog\Handler\StreamHandler;
+use Monolog\Logger;
+use Psr\Log\LoggerInterface;
+
+/**
+ * Registers log handlers
+ * Class LogManager
+ * @package Lib\Framework\Log
+ */
+class LogManager implements LoggerInterface
+{
+    /** @var ConfigManager */
+    protected $config;
+
+    /** @var LoggerInterface */
+    protected $logger;
+
+    /**
+     * LogManager constructor.
+     *
+     * @param \Lib\Framework\Container $container
+     * @throws \ReflectionException
+     */
+    public function __construct(Container $container)
+    {
+        $this->config = $container->get('Config');
+        $this->logger = $this->bootstrap();
+    }
+
+
+    /**
+     * Register Multiple Stream Handlers for every configured output.
+     *
+     * @throws \ReflectionException
+     * @throws \Exception
+     * @return LoggerInterface
+     */
+    public function bootstrap()
+    {
+        $logger = new Logger('CHASSISPHP');
+        foreach ($this->config->get('logging.output') as $level => $name) {
+            $prefix = date($this->config->get('logging.prefix.format')) . $this->config->get('logging.prefix.separator');
+            $logPath = $this->config->get('logging.folder') . DIRECTORY_SEPARATOR . $prefix . $name;
+            $logLevel = (new \ReflectionClass(Logger::class))->getConstant(strtoupper($level));
+            $logger->pushHandler(new StreamHandler(storagePath($logPath), $logLevel));
+        }
+        return $logger;
+    }
+
+    /**
+     * System is unusable.
+     *
+     * @param string $message
+     * @param array $context
+     *
+     * @return void
+     */
+    public function emergency($message, array $context = [])
+    {
+        $this->logger->emergency($message, $context);
+    }
+
+    /**
+     * Action must be taken immediately.
+     *
+     * Example: Entire website down, database unavailable, etc. This should
+     * trigger the SMS alerts and wake you up.
+     *
+     * @param string $message
+     * @param array $context
+     *
+     * @return void
+     */
+    public function alert($message, array $context = [])
+    {
+        $this->logger->alert($message, $context);
+    }
+
+    /**
+     * Critical conditions.
+     *
+     * Example: Application component unavailable, unexpected exception.
+     *
+     * @param string $message
+     * @param array $context
+     *
+     * @return void
+     */
+    public function critical($message, array $context = [])
+    {
+        $this->logger->critical($message, $context);
+    }
+
+    /**
+     * Runtime errors that do not require immediate action but should typically
+     * be logged and monitored.
+     *
+     * @param string $message
+     * @param array $context
+     *
+     * @return void
+     */
+    public function error($message, array $context = [])
+    {
+        $this->logger->error($message, $context);
+    }
+
+    /**
+     * Exceptional occurrences that are not errors.
+     *
+     * Example: Use of deprecated APIs, poor use of an API, undesirable things
+     * that are not necessarily wrong.
+     *
+     * @param string $message
+     * @param array $context
+     *
+     * @return void
+     */
+    public function warning($message, array $context = [])
+    {
+        $this->logger->warning($message, $context);
+    }
+
+    /**
+     * Normal but significant events.
+     *
+     * @param string $message
+     * @param array $context
+     *
+     * @return void
+     */
+    public function notice($message, array $context = [])
+    {
+        $this->logger->notice($message, $context);
+    }
+
+    /**
+     * Interesting events.
+     *
+     * Example: User logs in, SQL logs.
+     *
+     * @param string $message
+     * @param array $context
+     *
+     * @return void
+     */
+    public function info($message, array $context = [])
+    {
+        $this->logger->info($message, $context);
+    }
+
+    /**
+     * Detailed debug information.
+     *
+     * @param string $message
+     * @param array $context
+     *
+     * @return void
+     */
+    public function debug($message, array $context = [])
+    {
+        $this->logger->debug($message, $context);
+    }
+
+    /**
+     * Logs with an arbitrary level.
+     *
+     * @param mixed $level
+     * @param string $message
+     * @param array $context
+     *
+     * @return void
+     */
+    public function log($level, $message, array $context = [])
+    {
+        $this->logger->log($level, $message, $context);
+    }
+}

--- a/lib/Framework/helpers.php
+++ b/lib/Framework/helpers.php
@@ -37,3 +37,33 @@ if (! function_exists('baseURL')) {
         return $url;
     }
 }
+
+// Returns the path to the storage folder
+if (! function_exists('storagePath')) {
+    /**
+     * Path string to storage folder, when passed with appended $path
+     *
+     * @param string $path
+     * @return string
+     */
+    function storagePath($path = '')
+    {
+        $basePath = dirname(__DIR__, 2);
+        return $basePath . DIRECTORY_SEPARATOR . 'storage' . ($path ? DIRECTORY_SEPARATOR . $path : $path);
+    }
+}
+
+if (! function_exists('logTo')) {
+    /**
+     * Delegates logging to the registered Logger.
+     *
+     * @param $level
+     * @param $message
+     * @param array $context
+     */
+    function logTo($level, $message, $context = [])
+    {
+        // TODO avoid creating a new container for every log entry
+        (new \Lib\Framework\Container)->get('Logger')->log($level, $message, $context);
+    }
+}

--- a/public/index.php
+++ b/public/index.php
@@ -20,10 +20,9 @@ require __DIR__.'/../vendor/autoload.php';
 
 // set session storage location and
 // start the session
-$config = new \Lib\Framework\Config;
-$gcProb = $config['app']['gcProb'];
+$config = new \Lib\Framework\ConfigManager;
 ini_set('session.save_path', dirname(__FILE__, 2) . '/storage/sessions');
-ini_set('session.gc_probability', $gcProb);
+ini_set('session.gc_probability', $config->get('app.gcProb'));
 session_start();
 
 // set the timeout for the session

--- a/public/index.php
+++ b/public/index.php
@@ -20,9 +20,8 @@ require __DIR__.'/../vendor/autoload.php';
 
 // set session storage location and
 // start the session
-$config = new \Lib\Framework\ConfigManager;
 ini_set('session.save_path', dirname(__FILE__, 2) . '/storage/sessions');
-ini_set('session.gc_probability', $config->get('app.gcProb'));
+ini_set('session.gc_probability',\Lib\Framework\ConfigManager::get('app.gcProb'));
 session_start();
 
 // set the timeout for the session

--- a/public/index.php
+++ b/public/index.php
@@ -21,7 +21,7 @@ require __DIR__.'/../vendor/autoload.php';
 // set session storage location and
 // start the session
 $config = new \Lib\Framework\Config;
-$gcProb = $config['gcProb'];
+$gcProb = $config['app']['gcProb'];
 ini_set('session.save_path', dirname(__FILE__, 2) . '/storage/sessions');
 ini_set('session.gc_probability', $gcProb);
 session_start();


### PR DESCRIPTION
**Adds functionality to issue #54**

# Feature
This PR enables configuring multiple logging outputs and adds a helper to make logging easier.

## Configuration
* **folder** specifies a sub-folder within the storage folder where all logs get stored
* **prefix** used as DateFormat to prepend names of log files
* **output** defines a logging file, can be one for every log level

## Usage
````php
logTo('debug', 'MyMessage', $myContextArray);
````

# Disclaimer
I based this PR on [PR#328](https://github.com/RogerCreasy/ChassisPHP/pull/328) in order to more easily work with config variables.
If required, I'd rewrite the code to work without the ConfigManager.