### PR TITLE
EDIT prevent default submit behaviour, add redirect

### DIFF
--- a/resources/views/backend/pages/register.twig.php
+++ b/resources/views/backend/pages/register.twig.php
@@ -37,7 +37,7 @@
         <div class="form-group">
           <label>&nbsp;</label>
           <button type="submit">Save</button>
-          <button>Cancel</button>
+          <button onclick="event.preventDefault(); window.location.href='/backend/users'">Cancel</button>
         </div>
     </form>
 


### PR DESCRIPTION
# Bug
When leaving the form fields blank and clicking the cancel button, it submitted an empty form and created an empty user.

## Fix (Frontend only)
Let click on cancel button redirect back to users overview page.